### PR TITLE
Simplify std::enable_if use with decltype(auto)

### DIFF
--- a/src/ordered_guarded.hpp
+++ b/src/ordered_guarded.hpp
@@ -57,27 +57,10 @@ class ordered_guarded
     ordered_guarded(Us &&... data);
 
     template <typename Func>
-    typename std::enable_if<
-        std::is_same<decltype(std::declval<Func>()(std::declval<T &>())), void>::value, void>::type
-    modify(Func &&func);
+    decltype(auto) modify(Func &&func);
 
     template <typename Func>
-    typename std::enable_if<
-        !std::is_same<decltype(std::declval<Func>()(std::declval<T &>())), void>::value,
-        decltype(std::declval<Func>()(std::declval<T &>()))>::type
-    modify(Func &&func);
-
-    template <typename Func>
-    typename std::enable_if<
-        std::is_same<decltype(std::declval<Func>()(std::declval<const T &>())), void>::value,
-        void>::type
-    read(Func &&func) const;
-
-    template <typename Func>
-    typename std::enable_if<
-        !std::is_same<decltype(std::declval<Func>()(std::declval<const T &>())), void>::value,
-        decltype(std::declval<Func>()(std::declval<const T &>()))>::type
-    read(Func &&func) const;
+    decltype(auto) read(Func &&func) const;
 
     shared_handle lock_shared() const;
     shared_handle try_lock_shared() const;
@@ -121,21 +104,7 @@ ordered_guarded<T, M>::ordered_guarded(Us &&... data) : m_obj(std::forward<Us>(d
 
 template <typename T, typename M>
 template <typename Func>
-typename std::enable_if<
-    std::is_same<decltype(std::declval<Func>()(std::declval<T &>())), void>::value, void>::type
-ordered_guarded<T, M>::modify(Func &&func)
-{
-    std::lock_guard<M> lock(m_mutex);
-
-    func(m_obj);
-}
-
-template <typename T, typename M>
-template <typename Func>
-typename std::enable_if<
-    !std::is_same<decltype(std::declval<Func>()(std::declval<T &>())), void>::value,
-    decltype(std::declval<Func>()(std::declval<T &>()))>::type
-ordered_guarded<T, M>::modify(Func &&func)
+decltype(auto) ordered_guarded<T, M>::modify(Func &&func)
 {
     std::lock_guard<M> lock(m_mutex);
 
@@ -144,22 +113,7 @@ ordered_guarded<T, M>::modify(Func &&func)
 
 template <typename T, typename M>
 template <typename Func>
-typename std::enable_if<
-    std::is_same<decltype(std::declval<Func>()(std::declval<const T &>())), void>::value,
-    void>::type
-ordered_guarded<T, M>::read(Func &&func) const
-{
-    std::shared_lock<M> lock(m_mutex);
-
-    func(m_obj);
-}
-
-template <typename T, typename M>
-template <typename Func>
-typename std::enable_if<
-    !std::is_same<decltype(std::declval<Func>()(std::declval<const T &>())), void>::value,
-    decltype(std::declval<Func>()(std::declval<const T &>()))>::type
-ordered_guarded<T, M>::read(Func &&func) const
+decltype(auto) ordered_guarded<T, M>::read(Func &&func) const
 {
     std::shared_lock<M> lock(m_mutex);
 


### PR DESCRIPTION
Great library and fantastic work!
Here is a small change to reduce lines of code using decltype(auto) if you are interested. I only tested it on Linux (arch) but am sure it will work on any C++14 compliant compiler :crossed_fingers: .