### PR TITLE
Add missing include

### DIFF
--- a/src/cs_shared_guarded.h
+++ b/src/cs_shared_guarded.h
@@ -19,6 +19,7 @@
 #define CSLIBGUARDED_SHARED_GUARDED_H
 
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 
 namespace libguarded


### PR DESCRIPTION
libguarded::shared_guarded uses std::unique_lock which is defined in <mutex>