### PR TITLE
Fix array undefined

### DIFF
--- a/src/cs_lock_guards.h
+++ b/src/cs_lock_guards.h
@@ -19,6 +19,8 @@
 #define CSLIBGUARDED_LOCK_GUARDS_H
 
 #include <algorithm>
+#include <array>
+#include <tuple>
 #include <utility>
 
 namespace libguarded


### PR DESCRIPTION
Fix error: implicit instantiation of undefined template 'std::array` and `no member named 'apply' in namespace 'std'`