### PR TITLE
Support construction with allocators for allocator-aware types

### DIFF
--- a/src/cs_deferred_guarded.h
+++ b/src/cs_deferred_guarded.h
@@ -57,6 +57,9 @@ class deferred_guarded
       template <typename... Us>
       deferred_guarded(Us &&... data);
 
+      template <typename Alloc, typename... Us>
+      deferred_guarded(std::allocator_arg_t, Alloc alloc, Us &&... data);
+
       template <typename Func>
       void modify_detach(Func && func);
 
@@ -109,6 +112,16 @@ template <typename T, typename M>
 template <typename... Us>
 deferred_guarded<T, M>::deferred_guarded(Us &&... data)
    : m_obj(std::forward<Us>(data)...), m_pendingWrites(false)
+{
+}
+
+template <typename T, typename M>
+template <typename Alloc, typename... Us>
+deferred_guarded<T, M>::deferred_guarded(
+   std::allocator_arg_t,
+   Alloc alloc,
+   Us &&... data)
+   : m_obj(std::forward<Us>(data)..., alloc), m_pendingWrites(false)
 {
 }
 
@@ -295,5 +308,11 @@ auto deferred_guarded<T, M>::try_lock_shared_until(const TimePoint & tp) const -
 }
 
 }  // namespace libguarded
+
+template<typename T, typename M, typename Alloc>
+struct std::uses_allocator<libguarded::deferred_guarded<T, M>, Alloc>
+   : std::uses_allocator<T, Alloc>::type
+{
+};
 
 #endif

--- a/src/cs_ordered_guarded.h
+++ b/src/cs_ordered_guarded.h
@@ -56,6 +56,14 @@ class ordered_guarded
       template <typename... Us>
       ordered_guarded(Us &&... data);
 
+      /**
+        Construct a guarded object which uses an allocator. This
+        constructor will accept any number of parameters, all of which
+        are forwarded to the constructor of T.
+       */
+      template <typename Alloc, typename... Us>
+      ordered_guarded(std::allocator_arg_t, Alloc alloc, Us &&... data);
+
       template <typename Func>
       decltype(auto) modify(Func &&func);
 
@@ -102,6 +110,16 @@ template <typename T, typename M>
 template <typename... Us>
 ordered_guarded<T, M>::ordered_guarded(Us &&... data)
    : m_obj(std::forward<Us>(data)...)
+{
+}
+
+template <typename T, typename M>
+template <typename Alloc, typename... Us>
+ordered_guarded<T, M>::ordered_guarded(
+   std::allocator_arg_t,
+   Alloc alloc,
+   Us &&... data)
+   : m_obj(std::forward<Us>(data)..., alloc)
 {
 }
 
@@ -163,5 +181,11 @@ auto ordered_guarded<T, M>::try_lock_shared_until(const TimePoint &timepoint) co
 }
 
 }  // namespace libguarded
+
+template<typename T, typename M, typename Alloc>
+struct std::uses_allocator<libguarded::ordered_guarded<T, M>, Alloc>
+   : std::uses_allocator<T, Alloc>::type
+{
+};
 
 #endif

--- a/src/cs_shared_guarded.h
+++ b/src/cs_shared_guarded.h
@@ -52,6 +52,9 @@ class shared_guarded
       template <typename... Us>
       shared_guarded(Us &&... data);
 
+      template <typename Alloc, typename... Us>
+      shared_guarded(std::allocator_arg_t, Alloc alloc, Us &&... data);
+
       // exclusive access
       [[nodiscard]] handle lock();
       [[nodiscard]] handle try_lock();
@@ -139,6 +142,16 @@ template <typename T, typename M, typename L>
 template <typename... Us>
 shared_guarded<T, M, L>::shared_guarded(Us &&... data)
    : m_obj(std::forward<Us>(data)...)
+{
+}
+
+template <typename T, typename M, typename L>
+template <typename Alloc, typename... Us>
+shared_guarded<T, M, L>::shared_guarded(
+   std::allocator_arg_t,
+   Alloc alloc,
+   Us &&... data)
+   : m_obj(std::forward<Us>(data)..., alloc)
 {
 }
 
@@ -233,5 +246,11 @@ auto shared_guarded<T, M, L>::try_lock_shared_until(const TimePoint &tp) const -
 }
 
 }  // namespace libguarded
+
+template<typename T, typename M, typename L, typename Alloc>
+struct std::uses_allocator<libguarded::shared_guarded<T, M, L>, Alloc>
+   : std::uses_allocator<T, Alloc>::type
+{
+};
 
 #endif


### PR DESCRIPTION
Add a constructor and type trait specialization which is active if T is allocator-aware

This allows a std::shared_ptr for a guarded type to be constructed with std::allocate_shared.