### PR TITLE
Install cmake config files to the correct path on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,13 +98,7 @@ else()
 endif()
 
 # destination for cmake export files
-if (CMAKE_SYSTEM_NAME MATCHES "Windows")
-   set(PKG_PREFIX "cmake/CsLibGuarded")
-
-else()
-   set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CsLibGuarded")
-
-endif()
+set(PKG_PREFIX "${CMAKE_INSTALL_LIBDIR}/cmake/CsLibGuarded")
 
 # catch2 set up
 if(BUILD_TESTS)


### PR DESCRIPTION
I'm not sure why this branch is here, perhaps there is a good reason for it that I'm missing. But it results in CsLibGuardedConfig.cmake etc. being installed to `(install prefix)/cmake/CsLibGuarded/` on Windows, which is not a valid installation location as per the [CMake documentation](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure)

And so `find_package(CsLibGuarded)` will not be able to find the package at this location. Installing to `(install prefix)/lib/cmake/CsLibGuarded` on all platforms fixes this.